### PR TITLE
Add support for LaTeX Math Syntax

### DIFF
--- a/docs/media/mathjax.js
+++ b/docs/media/mathjax.js
@@ -1,0 +1,18 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document.addEventListener("DOMContentLoaded", function() {
+  if (typeof MathJax !== 'undefined') {
+    MathJax.typesetPromise();
+  }
+});

--- a/docs/media/mathjax.js
+++ b/docs/media/mathjax.js
@@ -16,3 +16,7 @@ document.addEventListener("DOMContentLoaded", function() {
     MathJax.typesetPromise();
   }
 });
+
+document.addEventListener("DOMContentSwitch", function() {
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,10 +115,16 @@ markdown_extensions:
       toc_depth: 3
   - admonition
   - pymdownx.blocks.admonition
+  - pymdownx.arithmatex:
+      generic: true
 
 extra:
   version:
     provider: mike
+
+extra_javascript:
+  - media/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 nav:
   - Home: index.md


### PR DESCRIPTION
This PR closes #66 by adding support for LaTeX Math Syntax through:
- the `arithmatex` Markdown extension;
- the `MathJax` JS script.

The deployed version of this branch can be seen [here](https://aptitude-consortium.github.io/wp2-trust-specifications/branch-fix-math-rendering/trust-framework/#trust-anchor-validation-process).