### PR TITLE
Update terminology following the release of TS03 v1.5

### DIFF
--- a/docs/topics/trust-anchor-validation.md
+++ b/docs/topics/trust-anchor-validation.md
@@ -4,7 +4,7 @@ Depending on the artifact or <credentials:Attestation> being verified, the valid
 
 1. *<artifacts:List of Trusted Entities (LoTE)>*, used to retrieve <artifacts:Trust Anchor|Trust Anchors> for validating the following:
    - **Infrastructure Certificates**: <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> or <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>.
-   - **Wallet Artifacts**: <artifacts:Wallet Unit Attestation (WUA)> or <artifacts:Wallet Instance Attestation (WIA)>.
+   - **<artifacts:Wallet Unit Attestations (WUAs)>**: <artifacts:Key Attestation (KA)> or <artifacts:Wallet Instance Attestation (WIA)>.
    - **PID Signatures**: <credentials:Person Identification Data (PID)>.
    - **<roles:Registrar>-signed artifacts**: <components:Register> informations.
 2. *<artifacts:EU Member State Trusted List (EUMS TL)|EU Member State Trusted Lists>* (<artifacts:EU Member State Trusted List (EUMS TL)|EUMS TL>); used to retrieve <artifacts:Trust Anchor|Trust Anchors> for validating the following:


### PR DESCRIPTION
This PR resolves #56 by applying the following changes:
- _Wallet Unit Attestation (WUA)_ --> _Key Attestation (KA)_;
- _Wallet Artifacts_ --> _Wallet Unit Attestations (WUAs)_.

No other relevant changes have been detected.

**Note**: this also requires to update the glossary in the RFC repository, for which the dedicated issue APTITUDE-Consortium/aptitude-eudi-wallet-specs#134 has been created.