### PR TITLE
Fix the example of organizationIdentifier value

### DIFF
--- a/docs/topics/access-certificate.md
+++ b/docs/topics/access-certificate.md
@@ -111,7 +111,7 @@ AccessCertificate cert = {
     subject: DistinguishedName {     // subject attributes for legal person 
       countryName: "FR", 
       organizationName: "Relying Party Example S.A.", 
-      organizationIdentifier: "LEIXYZ-5493001KJTIIGC8Y1R12", 
+      organizationIdentifier: "LEIXY-5493001KJTIIGC8Y1R12",
       commonName: "RP Example" 
     }, 
 
@@ -237,7 +237,7 @@ WRPAC cert = {
       givenName: "Alice", 
       surname: "Martin", 
       commonName: "Alice Martin", 
-      serialNumber: "PNO-FR-ALICEMARTIN-839201"
+      serialNumber: "PNOFR-ALICEMARTIN-839201"
     }, 
 
     subjectPublicKeyInfo: {


### PR DESCRIPTION
 - the specification ETSI EN 319 412-1 V1.6.1 in clause 5.1.4 defines that there has to be 3 characters for type identifier and 2 characters for country code, then hyphen