### PR TITLE
Refactor of AuthZ checks with WRPRC mandatory

### DIFF
--- a/docs/topics/authorization-process.md
+++ b/docs/topics/authorization-process.md
@@ -313,6 +313,10 @@ The intermediated RP name can be obtained from:
 
 If the intermediated RP name is not available, the <components:Wallet Instance|WI> SHALL display its identifier instead of the name.
 
+!!! choice "WRPRC and WRPAC binding"
+
+    As discussed in [#114](https://github.com/APTITUDE-Consortium/wp2-trust-specifications/issues/114), the APTITUDE Profiles do not implement the binding between WRPAC and WRPRC at the service level, as the necessary fields within the certificates are not described in the relevant technical specifications.
+
 !!! note
 
     The <roles:Registrar> online service API, including the specific parameters for querying intermediary relationships, is defined in TS5. This specification does not define the <components:Register> API; it only defines how the <components:Wallet Instance|WI> uses the <components:Register> response for authorization purposes.

--- a/docs/topics/authorization-process.md
+++ b/docs/topics/authorization-process.md
@@ -305,9 +305,11 @@ On failure of intermediary association verification, the procedure outputs SHALL
 **Step 4: Apply authorization context.** Once the intermediary association is confirmed, all subsequent authorization checks (entitlement verification, scope comparison, <artifacts:Embedded Disclosure Policy (EDP)|EDP> evaluation) SHALL use the intermediated <roles:Relying Party (RP)|RP> data, not the intermediary data [AUTHZ-INT-02].
 
 **Step 5: Display the final RP identity.** The <components:Wallet Instance|WI> SHALL display to the <roles:User> the intermediated RP identity and intended-use description. The intermediary identity SHALL NOT be displayed.
-The names are obtained from:
+The intermediated RP name can be obtained from:
 
-- Intermediated RP: `name` (or `sub_ln`) from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or the <components:Register> response, or the <roles:Relying Party (RP)|RP> name from the <artifacts:Presentation Request> fields per RPRC_19a (item a).
+- the `name` (or `sub_ln`) from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or
+- the <components:Register> response or
+- the <roles:Relying Party (RP)|RP> name from the <artifacts:Presentation Request> fields per RPRC_19a (item a).
 
 If the intermediated RP name is not available, the <components:Wallet Instance|WI> SHALL display its identifier instead of the name.
 
@@ -490,7 +492,7 @@ sequenceDiagram
             Note over WI: 5b. Extract registryURI from registrar_dataset
             WI->>Reg: 6b. Query registration data
             Reg-->>WI: 7b. Registration data
-            Note over WI: 8b. Register Validation Procedure
+            Note over WI: 4b. Register Response Validation Procedure
         end
     end
     Note over WI: 5. Binding Verification Procedure

--- a/docs/topics/authorization-process.md
+++ b/docs/topics/authorization-process.md
@@ -28,23 +28,25 @@ The <components:Wallet Instance|WI> SHALL distinguish between the authenticated 
 
 #### Source-Model Neutrality
 
-The <components:Wallet Instance|WI> SHALL support authorization-context resolution from a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> (where available) and from the <components:Register> (where a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not available or cannot be relied upon) [AUTHZ-GEN-05]. The substantive authorization logic SHALL NOT change based on the data source [AUTHZ-GEN-06]. Where both sources are available, the <components:Wallet Instance|WI> SHALL normalize both into the same internal authorization model before applying rules [AUTHZ-GEN-07].
+The issued <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> SHALL be the primary authorization evidence. The <components:Wallet Instance|WI> MAY use a verified <components:Register> response only for the permitted checks described below [AUTHZ-GEN-05]. The substantive authorization logic SHALL NOT change based on the data source [AUTHZ-GEN-06].
 
 #### Input Model
 
 The <components:Wallet Instance|WI> SHALL base authorization decisions only on information derived from [AUTHZ-IN-01]:
 
 - Already authenticated WRP context.
-- A verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or a verified <components:Register> response.
-- Explicitly identified self-declared fallback information.
+- A verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>.
+- A verified <components:Register> response, if the <components:Wallet Instance|WI> performs one of the permitted Register checks.
 - A verified <artifacts:Embedded Disclosure Policy (EDP)|EDP>, if provided by <roles:Attestation Provider (AP)|AP> during issuance.
 
 The <components:Wallet Instance|WI> SHALL maintain an internal distinction between the following input classes [AUTHZ-IN-02]:
 
 - **Authenticated WRP context**: authoritative only for the identity of the WRP [AUTHZ-IN-03].
 - **Verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>-derived or <components:Register>-derived information**: authoritative for subject identity, entitlements, intended use, registered scope, intermediary relationship, issuance-type information, and privacy-policy references [AUTHZ-IN-04 and AUTHZ-IN-05].
-- **Self-declared information**: non-authoritative. The <components:Wallet Instance|WI> SHALL NOT rely solely on self-declared information for checks that require registered information [AUTHZ-IN-06].
+- **Self-declared information**: non-authoritative. The <components:Wallet Instance|WI> SHALL NOT rely on self-declared information for checks that require registered information or use it as a fallback when <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or <components:Register> validation fails [AUTHZ-IN-06, AUTHZ-IN-10].
 - **Verified <artifacts:Embedded Disclosure Policy (EDP)|EDP>**: authoritative only if available. The <components:Wallet Instance|WI> SHALL rely on RP information to determine access permission [AUTHZ-<artifacts:Embedded Disclosure Policy (EDP)|EDP>-06].
+
+Self-declared metadata SHALL NOT be used to establish registration, entitlements, scope, intermediary relationships, or issuance authorization.
 
 Where authoritative sources conflict with non-authoritative sources, the authoritative sources SHALL supersede [AUTHZ-IN-07]. Where the authenticated WRP context conflicts with the identity or intermediary binding in the verified authorization context, the <components:Wallet Instance|WI> SHALL produce `NOT_AUTHORIZED` (non-overridable) [AUTHZ-IN-08].
 
@@ -88,7 +90,7 @@ In case of non-overridable failures, the <components:Wallet Instance|WI> SHALL c
 
 !!! note "User opt-in"
 
-    The *Scope Comparison Procedure* is executed only if the <roles:User> enabled registration verification (RPRC_16). Override mechanisms define what happens when the procedure produces a negative result.
+    The *WRPRC Validation Procedure* is mandatory. The *Scope Comparison Procedure* is executed only if the <roles:User> enabled scope comparison (RPRC_16). Override mechanisms define what happens when the procedure produces a negative result.
 
 The detailed override rules are provided in the [Override Rules](#override-rules) section.
 
@@ -98,7 +100,11 @@ This section describes the data objects that carry authorization information suc
 
 #### Registration Overview
 
-WRPs are registered with a <roles:Registrar> in their Member State before operating in the <components:EUDI Wallet> ecosystem. <roles:Relying Party (RP)|Relying Parties> declare one or more intended uses, each with a user-friendly description, the <data-elements:Attestation Type> and optionally the list of attributes needed, the purpose, and a privacy policy link. A <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is issued for each intended use (RPRC_09). <roles:Attestation Provider (AP)|Attestation Providers> declare which <data-elements:Attestation Type|Attestation types> they intend to issue (RPRC_15, RPRC_22a). <roles:Relying Party Intermediary (RPI)|Intermediaries> are registered as <roles:Relying Party (RP)|RPs> that act on behalf of other <roles:Relying Party (RP)|RPs>; the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> of the intermediated RP contains the `intermediary` structure identifying the authorized intermediary per [ETSI TS 119 475, Table 10].
+WRPs are registered with a <roles:Registrar> in their Member State before operating in the <components:EUDI Wallet> ecosystem. <roles:Relying Party (RP)|Relying Parties> declare one or more intended uses, each with a user-friendly description, the <data-elements:Attestation Type> and optionally the list of attributes needed, the purpose, and a privacy policy link. A <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> SHALL be issued for each intended use (RPRC_09). <roles:Attestation Provider (AP)|Attestation Providers> declare which <data-elements:Attestation Type|Attestation types> they intend to issue (RPRC_15, RPRC_22a). <roles:Relying Party Intermediary (RPI)|Intermediaries> are registered as <roles:Relying Party (RP)|RPs> that act on behalf of other <roles:Relying Party (RP)|RPs>; the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> of the intermediated RP contains the `intermediary` structure identifying the authorized intermediary per [ETSI TS 119 475, Table 10].
+
+!!! choice
+
+    The <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> SHALL be issued for each intended use, and the <components:Wallet Instance|WI> SHALL perform the WRPRC check. The WRPRC check is mandatory and SHALL NOT be skipped based on <roles:User> opt-in.
 
 #### Data Object Lifecycle
 
@@ -149,32 +155,7 @@ class REGDATA,WRPRC_OBJ,EDP_OBJ obj
 class META,PRES transport
 ```
 
-Registration data is collected at the <roles:Registrar> and the <roles:Provider of Wallet Relying Party Registration Certificate (Provider of WRPRC)|Provider of WRPRCs> get it from <roles:Registrar> to provide it through a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>. Registration data can also be queried directly by the <components:Wallet Instance|WI> using <roles:Registrar> online services as a fallback mechanism. <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRCs> are distributed to the <components:Wallet Instance|WI> through presentation requests (for RPs) or through <artifacts:Credential Issuer Metadata> (for <roles:Attestation Provider (AP)|APs>). EDPs are defined by the <roles:Attestation Provider (AP)|AP>, distributed through <artifacts:Credential Issuer Metadata>, stored locally by the <components:Wallet Instance|WI> during issuance, and evaluated at presentation time.
-
-#### WRPRC Parameters for Authorization
-
-The following table lists the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> payload parameters used in authorization processing, with field names as defined in [ETSI TS 119 475, Section 5.2.4]. Details about the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> data structure and lifecycle are provided in section [Wallet-Relying Party Registration Certificate](../sections/trust-artifacts.md#wallet-relying-party-registration-certificate).
-The **Authorization Use** column indicates how each parameter is consumed: **Decision rule** means the <components:Wallet Instance|WI> enforces an automated check, **User transparency** means the information is displayed to support the <roles:User>'s decision, and **Wallet operation** means the <components:Wallet Instance|WI> uses it internally (e.g. for fallback query).
-
-| Field | Applicability | Authorization Use | Reference |
-| :---- | :------------ | :---------------- | :-------- |
-| `sub` | WRPs (REQUIRED) | **Decision rule**: binding verification; entity identification for <artifacts:Embedded Disclosure Policy (EDP)\|EDP> evaluation | [ETSI TS 119 475, Table 7] RPRC_07 |
-| `sub_ln` | WRPs (REQUIRED) | **User transparency**: legal name displayed to User | [ETSI TS 119 475, Table 7], [CIR 2025/848, Annex I.1] |
-| `name` | WRPs (OPTIONAL) | **User transparency**: trade name displayed to User | [ETSI TS 119 475, Table 7], [CIR 2025/848, Annex I.2] |
-| `entitlements` | WRPs (REQUIRED) | **Decision rule**: entitlement verification against expected role | [ETSI TS 119 475, Table 7, Annex A.2] ISSU_24a, ISSU_34a |
-| `srv_description` | WRPs (REQUIRED) | **User transparency**: service description displayed to User | [ETSI TS 119 475, Table 7], [CIR 2025/848, Annex I.8] |
-| `registry_uri` | WRPs (REQUIRED) | **Wallet operation**: <roles:Registrar> URL for fallback query | [ETSI TS 119 475, Table 7] RPRC_18 |
-| `support_uri` | WRPs (REQUIRED) | **User transparency**: support contact for rights and data deletion | [ETSI TS 119 475, Table 7], [CIR 2025/848, Annex I.7(a)] |
-| `supervisory_authority` | WRPs (REQUIRED) | **User transparency**: DPA information displayed to User | [ETSI TS 119 475, Table 7], [CIR 2025/848, Annex IV.3(g)] |
-| `public_body` | WRPs (OPTIONAL) | **User transparency**: public sector identification shown to User | [ETSI TS 119 475, Table 10], [CIR 2025/848, Annex I.11] |
-| `privacy_policy` | RPs (REQUIRED if IntendedUse is present) | **User transparency**: privacy policy link displayed to User | [ETSI TS 119 475, Table 9] |
-| `purpose` | RPs (REQUIRED if IntendedUse is present) | **User transparency**: purpose description displayed to User | [ETSI TS 119 475, Table 9] RPRC_18 |
-| `intended_use_id` | RPs (OPTIONAL) | **Wallet operation**: <roles:Registrar> query key for intended-use lookup | [ETSI TS 119 475, Table 9] RPRC_19a |
-| `credentials[]` | RPs (OPTIONAL) | **Decision rule**: scope comparison bertween `claim[]` paths and `meta.vct_values`/`doctype_value` and requested attributes | [ETSI TS 119 475, Table 9] RPRC_09, RPRC_21 |
-| `provides_attestations[]` | APs (REQUIRED) | **Decision rule**: <data-elements:Attestation Type\|Attestation type> verification of registered types against requested type during issuance | [ETSI TS 119 475, Table 8] RPRC_15, RPRC_23, ISSU_34b |
-| `intermediary` | WRPs (OPTIONAL) | **Decision rule**: `intermediary.sub` used to check against authenticated intermediary identity | [ETSI TS 119 475, Table 10], [CIR 2025/848, Annex I.14] |
-| `status` | WRPs (REQUIRED) | **Decision rule**: <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> revocation check via <artifacts:Status List Token> | [ETSI TS 119 475] GEN-6.2.6.1-04, RPRC_17 |
-| `iat` / `exp` | WRPs (REQUIRED) | **Decision rule**: temporal validity check | [ETSI TS 119 475] |
+Registration data is collected at the <roles:Registrar> and the <roles:Provider of Wallet Relying Party Registration Certificate (Provider of WRPRC)|Provider of WRPRCs> get it from <roles:Registrar> to provide it through a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>. Registration data can also be queried directly by the <components:Wallet Instance|WI> using <roles:Registrar> online services for the permitted backup and binding checks. <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRCs> are distributed to the <components:Wallet Instance|WI> through presentation requests (for RPs) or through <artifacts:Credential Issuer Metadata> (for <roles:Attestation Provider (AP)|APs>). EDPs are defined by the <roles:Attestation Provider (AP)|AP>, distributed through <artifacts:Credential Issuer Metadata>, stored locally by the <components:Wallet Instance|WI> during issuance, and evaluated at presentation time.
 
 #### Distribution Methods
 
@@ -189,7 +170,7 @@ The **Authorization Use** column indicates how each parameter is consumed: **Dec
 
 **Issuance flow.** <roles:Attestation Provider (AP)|APs> include authorization data in <artifacts:Credential Issuer Metadata> through the `issuer_info` array ([ETSI TS 119 472-3, Section 4.2.3]). This array contains:
 
-- An element with format `"registration_cert"` containing the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> by value (ISS-MDATA-REG_CERT-4.2.3-04/05) (OPTIONAL).
+- An element with format `"registration_cert"` containing the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> by value (ISS-MDATA-REG_CERT-4.2.3-04/05) (REQUIRED).
 - An element with format `"registrar_dataset"` containing self-declared registration information including `identifier`, `srvDescription`, `registryURI`, and `providesAttestations` (ISS-MDATA-REG_CERT-4.2.3-07 through 13) (REQUIRED).
 
 Metadata is signed with the <roles:Attestation Provider (AP)|AP> <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> private key (ISSU_22a). Authorization data cointained in the <artifacts:Embedded Disclosure Policy (EDP)|EDP> is also distributed through <artifacts:Credential Issuer Metadata> within `credential_configurations_supported` field.
@@ -198,7 +179,14 @@ Metadata is signed with the <roles:Attestation Provider (AP)|AP> <artifacts:Wall
 
 Each <roles:Registrar> provides an online service accessible via URL, obtained as described in the [Distribution Methods](#distribution-methods) section.
 
-The <components:Wallet Instance|WI> SHALL use this service when the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not available or validation fails. The service is queried using the entity unique identifier and, for presentation, the `intended_use_id`. The response provides the same authorization-relevant data as a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>. <roles:Registrar> online service is available through an API interface which is defined in TS5.
+!!! choice
+
+    A <components:Wallet Instance|WI> MAY still use the <components:Register> APIs to:
+
+    - Check fresh Entity registration information as a backup to a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> failure.
+    - Check that the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> obtained by the <roles:Wallet-Relying Party (WRP)|WRP> is bound to the service with which the <components:Wallet Instance|WI> is interacting.
+
+The <components:Wallet Instance|WI> MAY use this service for either permitted check. The service is queried using the entity unique identifier and, for presentation, the `intended_use_id`. The response provides the same authorization-relevant data as a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>. A <components:Register> response SHALL NOT replace the mandatory WRPRC issuance or WRPRC check. The <roles:Registrar> online service is available through an API interface which is defined in [Register API](../topics/registry.md).
 
 !!! note
 
@@ -224,7 +212,9 @@ This section defines the individual verification procedures that are composed in
 
 #### WRPRC Validation Procedure
 
-When a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is available, the <components:Wallet Instance|WI> SHALL validate it before relying on it [AUTHZ-GEN-08]:
+The <components:Wallet Instance|WI> SHALL validate the issued <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> before relying on it [AUTHZ-GEN-08]. If the issued <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is absent, the mandatory check fails with `CERTIFICATE_INVALID`.
+
+The validation procedure is:
 
 1. **Format verification**: confirm `typ` is `rc-wrp+jwt` (remote) or `rc-wrp+cwt` (proximity)  ([ETSI TS 119 475, Section 5.2.1]).
 2. **Algorithm verification**: verify the conformance of signature algorithm (neither `"none"` nor deprecated).
@@ -234,11 +224,11 @@ When a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> i
 6. **Status verification**: check revocation status via the `status` field (RPRC_17).
 7. **Coherence check**: verify <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> subject and fields are coherent with the scenario [AUTHZ-GEN-09].
 
-If any step fails, the procedure outputs `CERTIFICATE_INVALID`. This is not a final authorization decision; it triggers the [Register Validation Procedure](#register-validation-procedure) as fallback.
+If any step fails, the procedure outputs `CERTIFICATE_INVALID`. This is not a final authorization decision; the <components:Wallet Instance|WI> MAY use the [Register Validation Procedure](#register-validation-procedure).
 
 #### Register Validation Procedure
 
-When the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not available or validation has failed, the <components:Wallet Instance|WI> SHALL attempt to contact the <components:Register> APIs [AUTHZ-GEN-10]:
+When the <components:Wallet Instance|WI> checks the entity's Authorization information, it MAY contact the <components:Register> APIs [AUTHZ-GEN-10]:
 
 1. **Extract <roles:Registrar> URL** from the <artifacts:Presentation Request> (`verifier_info` in remote scenario or `requestInfo` in proximity scanario) during presentation flow, or from <artifacts:Credential Issuer Metadata> (`issuer_info.registry_uri`) during issuance flow. See [Distribution Methods](#distribution-methods) section for details.
 2. **Connect** to the <roles:Registrar> online service using HTTPS.
@@ -250,7 +240,7 @@ When the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>
 
 If the URL is not present, connection fails, or validation fails, the procedure outputs `FAILED` [AUTHZ-REG-04].
 
-**Three-tier fallback (issuance only)** (ISSU_24a and ISSU_34a): self-declared data from `registrar_dataset` (advisory only, SHALL NOT be presented as verified) [AUTHZ-IN-10].
+There is no further fallback to self-declared metadata. If the WRPRC check fails and no Register check confirms the required authorization, the <components:Wallet Instance|WI> SHALL NOT use self-declared metadata to authorize the interaction or present it as verified [AUTHZ-IN-10]. For issuance, the <components:Wallet Instance|WI> SHALL block issuance; for presentation, it SHALL notify the <roles:User>.
 
 #### Binding Verification Procedure
 
@@ -260,8 +250,8 @@ The <components:Wallet Instance|WI> SHALL verify coherence between the authentic
 
 The WI SHALL compare the <roles:Wallet-Relying Party (WRP)|WRP> identifier extracted from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> subject (the `organizationIdentifier` in the subject DN, following [ETSI EN 319 412-1, clause 5.1.4]) against the authorization subject identifier available from:
 
-- the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field (if available).
-- The authorization data (RPRC_19a) extracted from authentication request (`verifier_info` or `requestInfo`) in presentation scenario or in `registrar_dataset` field in issuance scenario.
+- the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field, when the WRPRC check succeeds.
+- The authorization data (RPRC_19a) extracted from the authentication request (`verifier_info` or `requestInfo`) in the presentation scenario.
 - The <components:Register> response (if queried).
 
 All available sources SHALL be mutually consistent.
@@ -271,8 +261,8 @@ All available sources SHALL be mutually consistent.
 During issuance, the <components:Wallet Instance|WI> SHALL verify that the <roles:Attestation Provider (AP)|AP> that signed the <artifacts:Credential Issuer Metadata> (identified by the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> in the `x5c` header of the JWS) is the same entity described in the authorization data [AUTHZ-GEN-11]. The <components:Wallet Instance|WI> SHALL check coherence between:
 
 - The <roles:Attestation Provider (AP)|AP> identifier from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> subject (extracted during metadata signature verification).
-- The `sub` field from the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> in `issuer_info` (if present).
-- The `identifier` field from the `registrar_dataset` element in `issuer_info` (if present).
+- The `sub` field from the issued and validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> in `issuer_info`.
+- The `identifier` field from a verified <components:Register> response (if queried).
 
 If any pair of these identifiers is inconsistent, the procedure outputs `BINDING_FAILED`. Intermediary detection does not apply to issuance.
 
@@ -287,11 +277,11 @@ If the two identifiers match, the **direct RP scenario** applies. If they differ
 
 ##### Direct RP Binding
 
-In the direct <roles:Relying Party (RP)|RP> scenario, the <components:Wallet Instance|WI> SHALL verify that the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> (if present in `verifier_info` or `requestInfo`) is coherent with the already-established identities [AUTHZ-GEN-12]:
+In the direct <roles:Relying Party (RP)|RP> scenario, the <components:Wallet Instance|WI> SHALL verify that the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or verified <components:Register> response is coherent with the already-established identities [AUTHZ-GEN-12]:
 
-- The <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field SHALL match the authenticated WRP identifier and the claimed <roles:Relying Party (RP)|RP> identifier from authorization data (RPRC_19a).
+- The authorization subject identifier from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or verified <components:Register> response SHALL match the authenticated WRP identifier and the claimed <roles:Relying Party (RP)|RP> identifier from authorization data (RPRC_19a).
 
-If the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` does not match, the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not valid for this <roles:Relying Party (RP)|RP>. The procedure outputs `BINDING_FAILED` and the WI SHALL discard the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> and fall back to the [Register Validation Procedure](#register-validation-procedure).
+If the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` does not match, the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not valid for this <roles:Relying Party (RP)|RP>. The procedure outputs `BINDING_FAILED` and the WI SHALL discard the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>; it MAY use the [Register Validation Procedure](#register-validation-procedure) for a permitted check.
 
 ##### Intermediary Binding
 
@@ -300,31 +290,26 @@ In the intermediary scenario, the <components:Wallet Instance|WI> SHALL perform 
 **Step 1: Identify the parties.** The <components:Wallet Instance|WI> identifies:
 
 - The **intermediary**: the entity authenticated via <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC>. Its identifier is extracted from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> subject DN.
-- The **intermediated (final) RP**: the authorization subject. Its identifier and other data are obtained from the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field and/or from the <artifacts:Presentation Request> fields.
+- The **intermediated (final) RP**: the authorization subject. Its identifier and other data are obtained from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>, (optionally) a verified <components:Register> response, and/or the <artifacts:Presentation Request> fields.
 
 **Step 2: Verify intermediary association.** The <components:Wallet Instance|WI> SHALL verify that the intermediary is authorized to act on behalf of the intermediated RP. The verification depends on the available data source:
 
-- **If a valid <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is available**: the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> of the intermediated RP SHALL contain the `intermediary` structure (per [ETSI TS 119 475, Table 10]). The WI SHALL verify that `intermediary.sub` matches the authenticated intermediary identifier from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC>. The presence of the `intermediary` field in the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>, signed by the <roles:Provider of Wallet Relying Party Registration Certificate (Provider of WRPRC)|Provider of WRPRCs>, is authoritative evidence that the relationship is registered.
-- **If the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is not available or invalid**: the <components:Wallet Instance|WI> SHALL query the <components:Register> using the intermediated RP identifier (from RPRC_19a item b) and verify in the <components:Register> response that the authenticated intermediary is listed as an authorized intermediary for that RP.
+- **If the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> check succeeds**: the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> of the intermediated RP SHALL contain the `intermediary` structure (per [ETSI TS 119 475, Table 10]). The WI SHALL verify that `intermediary.sub` matches the authenticated intermediary identifier from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC>. The presence of the `intermediary` field in the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>, signed by the <roles:Provider of Wallet Relying Party Registration Certificate (Provider of WRPRC)|Provider of WRPRCs>, is authoritative evidence that the relationship is registered.
+- **If the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> check fails**: the <components:Wallet Instance|WI> MAY query the <components:Register> using the intermediated RP identifier (from RPRC_19a item b) and verify in the <components:Register> response that the authenticated intermediary is listed as an authorized intermediary for that RP.
 - **If both <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> and <components:Register> verification fail**: the <components:Wallet Instance|WI> SHALL NOT confirm the intermediary relationship.
 
 On failure of intermediary association verification, the procedure outputs SHALL be `INTERMEDIARY_NOT_AUTHORIZED` [AUTHZ-INT-03].
 
-**Step 3: Verify authorization subject coherence.** The <components:Wallet Instance|WI> SHALL additionally verify that the intermediated RP identifier is consistent across all available sources: the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field (if available), the presentation request fields per RPRC_19a, and the <components:Register> response (if queried). If any inconsistency is found, the procedure SHALL output `BINDING_FAILED`.
+**Step 3: Verify authorization subject coherence.** The <components:Wallet Instance|WI> SHALL additionally verify that the intermediated RP identifier is consistent across all available sources: the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> `sub` field when the WRPRC check succeeds, the presentation request fields per RPRC_19a, and the <components:Register> response (if queried). If any inconsistency is found, the procedure SHALL output `BINDING_FAILED`.
 
 **Step 4: Apply authorization context.** Once the intermediary association is confirmed, all subsequent authorization checks (entitlement verification, scope comparison, <artifacts:Embedded Disclosure Policy (EDP)|EDP> evaluation) SHALL use the intermediated <roles:Relying Party (RP)|RP> data, not the intermediary data [AUTHZ-INT-02].
 
-**Step 5: Display both identities.** The <components:Wallet Instance|WI> SHALL display to the <roles:User> both the intermediary identity and the intermediated RP identity (RPI_07). The display SHOULD follow the pattern: "[intermediary name] acting on behalf of [intermediated RP name] for [intended use description]".
+**Step 5: Display the final RP identity.** The <components:Wallet Instance|WI> SHALL display to the <roles:User> the intermediated RP identity and intended-use description. The intermediary identity SHALL NOT be displayed.
 The names are obtained from:
 
-- Intermediary: `intermediary.sname` from the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>, or the intermediary name from the <components:Register> response.
-- Intermediated RP: `name` (or `sub_ln`) from the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC>, or the <roles:Relying Party (RP)|RP> name from the <artifacts:Presentation Request> fields per RPRC_19a (item a), or the <components:Register> response.
+- Intermediated RP: `name` (or `sub_ln`) from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or the <components:Register> response, or the <roles:Relying Party (RP)|RP> name from the <artifacts:Presentation Request> fields per RPRC_19a (item a).
 
-If any name is not available, the <components:Wallet Instance|WI> SHALL display the identifier instead of the name.
-
-!!! warning
-
-    [ETSI TS 119 475, Table 10] defines the intermediary name subfield > as `sname`. The example in Annex C of the same standard uses `name` instead. This specification follows the normative Table 10 and uses `sname`.
+If the intermediated RP name is not available, the <components:Wallet Instance|WI> SHALL display its identifier instead of the name.
 
 !!! note
 
@@ -373,7 +358,7 @@ In case of **Authorized Relying Parties Only** policy type [AUTHZ-EDP-04]:
 
 - Detect intermediary scenario.
 - Extract the identity information of the <roles:Relying Party (RP)|RP> (direct) or intermediated RP. The <components:Wallet Instance|WI> SHALL NOT use intermediary identity.
-- Match against the `authorized_parties` list: compare the <roles:Relying Party (RP)|RP> subject DN from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> against `subject_dn` entries, and/or compare the RP entitlements or sub-entitlements from <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> against `entitlement_uri` entries. A match on either criterion is sufficient.
+- Match against the `authorized_parties` list: compare the <roles:Relying Party (RP)|RP> subject DN from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> against `subject_dn` entries, and/or compare the RP entitlements or sub-entitlements from the validated <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> or verified <components:Register> response against `entitlement_uri` entries. A match on either criterion is sufficient.
 
 If the checks are successful, the <components:Wallet Instance|WI> SHALL provide `EDP_SATISFIED` as output result, otherwise the <components:Wallet Instance|WI> SHALL provide `EDP_NOT_SATISFIED`.
 
@@ -393,7 +378,7 @@ This section details the override behaviour for each procedure when it provides 
 
 | Evaluation Procedure | Phase | Negative Outcome | User Override |
 |---------------------|-------|-----------------|---------------|
-| <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> Validation | Both | `CERTIFICATE_INVALID` | It triggers *<components:Register> Validation* as fallback. <roles:User> is not involved |
+| <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> Validation | Both | `CERTIFICATE_INVALID` | <components:Register> APIs MAY be used for one of the permitted checks. <roles:User> is not involved |
 | <components:Register> Validation | Issuance | `FAILED` | Non-overridable [AUTHZ-ISS-01], [AUTHZ-UI-06] |
 | <components:Register> Validation | Presentation | `FAILED` | Overridable. Advisory to User [AUTHZ-PRES-06] |
 | Binding Verification | Issuance | `BINDING_FAILED` | Non-overridable [AUTHZ-UI-06] |
@@ -428,16 +413,18 @@ sequenceDiagram
 
     Note over WI: 4. Verify metadata signature (WRPAC)
 
-    alt WRPRC in issuer_info (format "registration_cert")
+    alt Valid WRPRC in issuer_info (format "registration_cert")
         Note over WI: 5a. Extract WRPRC
         WI->>TL: 6a. Fetch trust anchor
         TL-->>WI: 7a. Trust anchor
         Note over WI: 8a. WRPRC Validation Procedure
-    else WRPRC absent or invalid
-        Note over WI: 5b. Extract registryURI from registrar_dataset
-        WI->>Reg: 6b. Query registration data
-        Reg-->>WI: 7b. Registration data
-        Note over WI: 8b. Register Validation Procedure
+    else invalid WRPRC
+        opt Register backup check
+            Note over WI: 5b. Extract registryURI from registrar_dataset
+            WI->>Reg: 6b. Query registration data
+            Reg-->>WI: 7b. Registration data
+            Note over WI: 8b. Register Validation Procedure
+        end
     end
 
     Note over WI: 9. Binding Verification Procedure
@@ -460,9 +447,9 @@ sequenceDiagram
 
 **Step 4: Verify metadata signature.** The <components:Wallet Instance|WI> SHALL verify the metadata signature and <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> certificate chain [AUTHZ-ISS-05]. If verification fails, the <components:Wallet Instance|WI> provides `NOT_AUTHORIZED` code (non-overridable) [AUTHZ-ISS-06].
 
-**Steps 5-8: Extract authorization data.** The <components:Wallet Instance|WI> SHALL extract data from the `issuer_info` array [AUTHZ-ISS-07]. If a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> is present (steps 5a-8a), apply the *<artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> Validation Procedure*. If absent or invalid (steps 5b-8b), apply the *<components:Register> Validation Procedure*. If both fail, apply the three-tier fallback; self-declared data SHALL be treated as advisory only [AUTHZ-ISS-08], [AUTHZ-ISS-09].
+**Steps 5-8: Extract authorization data.** The <components:Wallet Instance|WI> SHALL extract data from the `issuer_info` array [AUTHZ-ISS-07] and SHALL validate the required <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> using the *<artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> Validation Procedure*. If the WRPRC is missing or invalid, the <components:Wallet Instance|WI> MAY use the *<components:Register> Validation Procedure* for a backup check. If the WRPRC check succeeds, the <components:Wallet Instance|WI> MAY use the <components:Register> for the permitted service-binding check. If the WRPRC check fails and no permitted Register check confirms the required authorization, the <components:Wallet Instance|WI> SHALL NOT use self-declared data as a fallback and SHALL block issuance [AUTHZ-ISS-08], [AUTHZ-ISS-09].
 
-**Step 9: Binding verification.** Apply the *Binding Verification Procedure* (issuance binding): verify that the <roles:Attestation Provider (AP)|AP> identifier from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> (used to sign the metadata) is coherent with the `sub` in the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> and the `identifier` in the `registrar_dataset` [AUTHZ-GEN-11]. If incoherent, the WI returns `NOT_AUTHORIZED` code (non-overridable).
+**Step 9: Binding verification.** Apply the *Binding Verification Procedure* (issuance binding): verify that the <roles:Attestation Provider (AP)|AP> identifier from the <artifacts:Wallet-Relying Party Access Certificate (WRPAC)|WRPAC> (used to sign the metadata) is coherent with the `sub` in the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> and the `identifier` in a verified <components:Register> response, if queried [AUTHZ-GEN-11]. If incoherent, the WI returns `NOT_AUTHORIZED` code (non-overridable).
 
 **Step 10: <data-elements:Entitlement> verification.** Apply the *<data-elements:Entitlement> Verification Procedure*. If not confirmed, the WI provides `NOT_AUTHORIZED` code(non-overridable) [AUTHZ-ISS-01].
 
@@ -494,21 +481,24 @@ sequenceDiagram
 
     RP->>WI: 1. Presentation Request
 
-    alt User opted-in to verify
-        alt WRPRC present
-            WI->>TL: 2a. Fetch trust anchor
-            TL-->>WI: 3a. Trust anchor
-            Note over WI: 4a. WRPRC Validation Procedure
-        else WRPRC missing or invalid
-            WI->>Reg: 2b. Query registration data
-            Reg-->>WI: 3b. Registration data
-            Note over WI: 4b. Registrar Validation Procedure
+    alt Valid WRPRC present
+        WI->>TL: 2a. Fetch trust anchor
+        TL-->>WI: 3a. Trust anchor
+        Note over WI: 4a. WRPRC Validation Procedure
+    else invalid WRPRC
+        opt Register backup check
+            Note over WI: 5b. Extract registryURI from registrar_dataset
+            WI->>Reg: 6b. Query registration data
+            Reg-->>WI: 7b. Registration data
+            Note over WI: 8b. Register Validation Procedure
         end
-        Note over WI: 5. Binding Verification Procedure
-        Note over WI: 6. Entitlement Verification Procedure
+    end
+    Note over WI: 5. Binding Verification Procedure
+    Note over WI: 6. Entitlement Verification Procedure
+    alt User opted-in to scope comparison
         Note over WI: 7. Scope Comparison Procedure
     else User NOT opted-in
-        Note over WI: Skip registration verification
+        Note over WI: Skip optional Scope Comparison Procedure
     end
 
     Note over WI: 8. EDP Evaluation Procedure (always)
@@ -518,13 +508,13 @@ sequenceDiagram
 
 ##### Step-by-step Operations
 
-**Step 1: Receive request and check User opt-in.** The <components:Wallet Instance|WI> SHALL offer a <roles:User> setting for <roles:Relying Party (RP)|RP> verification, enabled by default [AUTHZ-PRES-04]. If opted-in, proceed to step 2. Otherwise skip to step 8.
+**Step 1: Receive request.** The <components:Wallet Instance|WI> SHALL perform the mandatory <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> check. The <roles:User> setting applies only to the optional Scope Comparison Procedure [AUTHZ-PRES-04].
 
 !!! note
 
-    If opted-in, the <components:Wallet Instance|WI> executes the full registration verification block: evidence collection, binding verification, entitlement verification, and scope comparison (steps 2-7). If not opted-in, the <components:Wallet Instance|WI> skips these steps and proceeds directly to <artifacts:Embedded Disclosure Policy (EDP)|EDP> evaluation (step 8), which is always executed.
+    The <components:Wallet Instance|WI> always executes WRPRC validation, binding verification, and entitlement verification (steps 2-6). If the WRPRC check fails, the <components:Wallet Instance|WI> MAY use the <components:Register> API to retrieve the necessary informations. <artifacts:Embedded Disclosure Policy (EDP)|EDP> evaluation (step 8) is always executed.
 
-**Steps 2-4: Collect authorization evidence.** Extract the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> from the request [AUTHZ-PRES-05]: from `verifier_info` (remote) or `euWrprc` in `requestInfo` (proximity). If present, apply the *<artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> Validation Procedure*. If absent or invalid, apply the *<components:Register> Validation Procedure* using `registry_uri` from the request extension and the RP identifier with `intended_use_id`. If lookup fails, notify User, record `FAILED`, proceed with advisory [AUTHZ-PRES-06].
+**Steps 2-4: Collect authorization evidence.** Extract the required <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> from the request [AUTHZ-PRES-05]: from `verifier_info` (remote) or `euWrprc` in `requestInfo` (proximity), and apply the *<artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> Validation Procedure*. If the WRPRC is missing or invalid, the <components:Wallet Instance|WI> MAY use the *<components:Register> Validation Procedure*. If the WRPRC check succeeds, the <components:Wallet Instance|WI> MAY use the <components:Register> to check that the certificate obtained by the WRP is bound to the service being used. If a lookup fails, the <components:Wallet Instance|WI> SHALL NOT use self-declared metadata as a fallback; instead it SHALL notify User, record `FAILED`, and proceed only with the presentation advisory and override rules [AUTHZ-PRES-06].
 
 **Step 5: Binding verification.** Apply the *Binding Verification Procedure* (direct or intermediary) [AUTHZ-PRES-07].
 
@@ -534,10 +524,9 @@ sequenceDiagram
 
 **Step 8: <artifacts:Embedded Disclosure Policy (EDP)|EDP> evaluation.** Always executed regardless of registration verification [AUTHZ-<artifacts:Embedded Disclosure Policy (EDP)|EDP>-09]. Apply the *<artifacts:Embedded Disclosure Policy (EDP)|EDP> Evaluation Procedure* for each matching Attestation.
 
-**Steps 9-10: User approval.** Present all results and request approval [AUTHZ-UI-07], [AUTHZ-UI-10]. Display at least [AUTHZ-UI-08],[AUTHZ-INT-05]:
+**Steps 9-10: User approval.** Present all results and request approval [AUTHZ-UI-07], [AUTHZ-UI-10]. Display at least [AUTHZ-UI-08], [AUTHZ-INT-05]:
 
 - RP/final RP identity,
-- intermediary identity where applicable,
 - requested attributes,
 - intended-use description,
 - privacy-policy link,  
@@ -547,7 +536,7 @@ If `AUTHORIZED`, the <components:Wallet Instance|WI> SHALL proceed to normal Use
 
 ##### Remote Flow Specifics
 
-The RP Instance SHALL include RPRC_19a extension fields and, if available, the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> by value (RPRC_19) [AUTHZ-PRES-10]. The <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> SHALL be JWT (`typ = "rc-wrp+jwt"`). Requested attributes SHALL be extracted from DCQL `credential_queries[].claims[]` paths.
+The RP Instance SHALL include RPRC_19a extension fields and the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> by value (RPRC_19) [AUTHZ-PRES-10]. The <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)|WRPRC> SHALL be JWT (`typ = "rc-wrp+jwt"`). Requested attributes SHALL be extracted from DCQL `credential_queries[].claims[]` paths.
 
 ##### Proximity Flow Specifics
 
@@ -560,7 +549,7 @@ Intermediary handling applies to both flows [AUTHZ-INT-04]. The <components:Wall
 - Authenticate the intermediary through its Access Certificate.
 - Detect the intermediary scenario.
 - Apply all authorization checks using the intermediated RP context.
-- Display both identities (RPI_07).
+- Display the intermediated RP identity; the intermediary identity SHALL NOT be displayed.
 
 Negative cases SHALL result in `NOT_AUTHORIZED` code [AUTHZ-INT-06]. Override is allowed only for negative scope and negative <artifacts:Embedded Disclosure Policy (EDP)|EDP> [AUTHZ-INT-07].
 
@@ -568,14 +557,16 @@ Negative cases SHALL result in `NOT_AUTHORIZED` code [AUTHZ-INT-06]. Override is
 
 ```mermaid
 flowchart TD
-    Start([Presentation request received]) --> UserOptIn{User opted-in<br/>to verify?}
+    Start([Presentation request received]) --> ObtainData[Mandatory WRPRC validation]
 
-    UserOptIn -->|Yes| ObtainData[Obtain authorization data<br/>WRPRC or Register]
-    UserOptIn -->|No| SkipVerif[Skip registration verification]
-
-    ObtainData --> DataOK{Data<br/>obtained?}
-    DataOK -->|No| WarnNoData[Advisory: cannot verify RP]
-    DataOK -->|Yes| Binding[Binding Verification]
+    ObtainData --> DataOK{WRPRC check<br/>passed?}
+    DataOK -->|No| RegisterChoice{Use Register<br/>check?}
+    RegisterChoice -->|Yes| RegisterData[Query Register]
+    RegisterChoice -->|No| WarnNoData[Advisory: cannot verify RP]
+    RegisterData --> RegisterOK{Register<br/>check passed?}
+    RegisterOK -->|No| WarnNoData
+    RegisterOK -->|Yes| Binding[Binding Verification]
+    DataOK -->|Yes| Binding
 
     Binding --> BindOK{Binding<br/>OK?}
     BindOK -->|No| BlockBinding[NOT_AUTHORIZED]
@@ -583,14 +574,16 @@ flowchart TD
 
     Entitlement --> EntOK{Entitlement<br/>OK?}
     EntOK -->|No| WarnEnt[Advisory: wrong entitlement]
-    EntOK -->|Yes| Scope[Scope Comparison]
+    EntOK -->|Yes| UserOptIn{User opted-in<br/>to scope comparison?}
+    UserOptIn -->|Yes| Scope[Scope Comparison]
+    UserOptIn -->|No| RegPassed[Registration checks complete]
 
     Scope --> ScopeOK{All attributes<br/>registered?}
-    ScopeOK -->|Yes| RegPassed[Verification PASSED]
+    ScopeOK -->|Yes| RegPassed
     ScopeOK -->|No| WarnScope[Advisory: unregistered attributes]
 
-    WarnNoData --> UserReg{User decision}
-    WarnEnt --> UserReg
+    WarnNoData --> |Deny| Deny
+    WarnEnt --> UserReg{User decision}
     WarnScope --> UserReg
 
     UserReg -->|Deny| Deny[Deny presentation]
@@ -598,7 +591,6 @@ flowchart TD
 
     RegPassed --> EDP
     RegWarning --> EDP
-    SkipVerif --> EDP
 
     EDP[EDP Evaluation<br/>for each Attestation]
     EDP --> HasEDP{Has EDP?}
@@ -644,25 +636,25 @@ flowchart TD
 | AUTHZ-GEN-02 | If the WRP has not been authenticated, the authorization process SHALL NOT start. | Both | -- |
 | AUTHZ-GEN-03 | A conformant wallet SHALL implement all authorization-processing rules defined in this specification. | Both | -- |
 | AUTHZ-GEN-04 | The WI SHALL distinguish between the authenticated WRP and the authorization subject. | Both | -- |
-| AUTHZ-GEN-05 | The WI SHALL support authorization-context resolution from <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> and <components:Register>. | Both | RPRC_16, RPRC_18 |
+| AUTHZ-GEN-05 | The WI SHALL use the issued <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> as the primary authorization evidence and MAY use a verified <components:Register> response. | Both | RPRC_16, RPRC_18 |
 | AUTHZ-GEN-06 | The authorization logic SHALL NOT change based on the data source. | Both | -- |
 | AUTHZ-GEN-07 | Where both <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> and <components:Register> data are available, the WI SHALL normalize both into the same model. | Both | -- |
-| AUTHZ-GEN-08 | When a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> is available, the WI SHALL validate its authenticity, integrity, temporal validity, and status before relying on it. | Both | RPRC_17 |
+| AUTHZ-GEN-08 | The WI SHALL validate the issued <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> for authenticity, integrity, temporal validity, status, and scenario coherence before relying on it. | Both | RPRC_17 |
 | AUTHZ-GEN-09 | <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> validation SHALL include coherence check between <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> subject and scenario context. | Both | -- |
-| AUTHZ-GEN-10 | When <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> is not available or validation failed, the WI SHALL attempt querying the <components:Register>. | Both | RPRC_18 |
+| AUTHZ-GEN-10 | The WI MAY use the <components:Register> APIs only to check fresh Entity registration information as a backup to a <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> failure or to check that the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> obtained by the WRP is bound to the service being used. | Both | RPRC_18 |
 | AUTHZ-GEN-11 | The WI SHALL verify coherence between authenticated WRP and authorization context in both issuance and presentation. | Both | -- |
-| AUTHZ-GEN-12 | For direct RP in presentation, the WI SHALL verify RP identifier from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> matches `sub` in authorization context and RPRC_19a identifier. For issuance, the WI SHALL verify AP identifier from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> matches `sub` in <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> and `identifier` in registrar_dataset. | Both | RPRC_07, RPRC_08 |
+| AUTHZ-GEN-12 | For direct RP in presentation, the WI SHALL verify RP identifier from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> matches `sub` in authorization context and RPRC_19a identifier. For issuance, the WI SHALL verify AP identifier from <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> matches `sub` in <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> and `identifier` in a verified <components:Register> response, if queried. | Both | RPRC_07, RPRC_08 |
 | AUTHZ-GEN-13 | The WI SHALL verify that entitlements match the expected role. | Both | ISSU_24a, ISSU_34a |
-| AUTHZ-IN-01 | Authorization decisions SHALL be based only on authenticated context, verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC>, verified <components:Register>, verified <artifacts:Embedded Disclosure Policy (EDP)\|EDP>, or identified self-declared fallback. | Both | -- |
+| AUTHZ-IN-01 | Authorization decisions SHALL be based only on authenticated context, verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC>, verified <components:Register>, or verified <artifacts:Embedded Disclosure Policy (EDP)\|EDP>. | Both | -- |
 | AUTHZ-IN-02 | The WI SHALL maintain internal distinction between input classes. | Both | -- |
 | AUTHZ-IN-03 | Authenticated WRP context is authoritative only for WRP identity. | Both | -- |
 | AUTHZ-IN-04 | Verified <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC>-derived information is authoritative for subject identity, entitlements, scope, etc. | Both | -- |
 | AUTHZ-IN-05 | Verified <components:Register>-derived information is authoritative for the same data set. | Both | -- |
-| AUTHZ-IN-06 | The WI SHALL NOT rely solely on self-declared information for checks requiring registered information. | Both | ISSU_24a note, ISSU_34a note |
+| AUTHZ-IN-06 | The WI SHALL NOT use self-declared information for checks requiring registered information or as a fallback when <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> or <components:Register> validation fails. | Both | ISSU_24a note, ISSU_34a note |
 | AUTHZ-IN-07 | Authoritative sources SHALL prevail over non-authoritative sources. | Both | -- |
 | AUTHZ-IN-08 | Identity conflict between authenticated context and authorization context produces NOT_AUTHORIZED (non-overridable). | Both | -- |
 | AUTHZ-IN-09 | A request-carried <components:Register> URL SHALL NOT be treated as proof of registration; MAY be used as a discovery hint. | Both | -- |
-| AUTHZ-IN-10 | Self-declared fallback information SHALL NOT be presented as verified registration information. | Issuance | ISSU_24a note |
+| AUTHZ-IN-10 | Self-declared metadata SHALL NOT be used as an authorization fallback when <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> or <components:Register> validation fails. | Both | RPRC_18, ISSU_24a note |
 | AUTHZ-UI-01 | The WI SHALL produce AUTHORIZED or NOT_AUTHORIZED. | Both | -- |
 | AUTHZ-UI-02 | User-relevant limitations SHALL be represented as advisories. | Both | -- |
 | AUTHZ-UI-03 | Advisories SHALL be displayed to the Wallet User. | Both | -- |
@@ -670,7 +662,7 @@ flowchart TD
 | AUTHZ-UI-05 | The process SHALL support transparent decision-making and SHALL NOT be purely hidden. | Both | [CIR 2025/848] |
 | AUTHZ-UI-06 | Non-overridable cases: provider role/type failure in issuance, metadata signature failure, coherence failure, intermediary binding failure, registration status failure, missing minimum info, inability to obtain required authoritative info for issuance. | Both | ISSU_24a, ISSU_34a, RPRC_23 |
 | AUTHZ-UI-07 | For presentation, the WI SHALL present all results and advisories and request User approval. | Presentation | RPA_07 |
-| AUTHZ-UI-08 | For presentation, the WI SHALL show at minimum: RP identity, intermediary identity, requested attributes, intended-use, privacy-policy, advisories. | Presentation | RPRC_19a, RPI_07 |
+| AUTHZ-UI-08 | For presentation, the WI SHALL show at minimum: RP/final RP identity, requested attributes, intended-use, privacy-policy, advisories. The intermediary identity SHALL NOT be displayed. | Presentation | RPRC_19a |
 | AUTHZ-UI-09 | For issuance, the WI SHALL show at minimum: provider name/type, attestation type, service description, advisories. | Issuance | RPRC_22a |
 | AUTHZ-UI-10 | If AUTHORIZED, proceed to normal User approval. | Both | RPA_07 |
 | AUTHZ-UI-11 | If NOT_AUTHORIZED and override allowed, present negative outcome and MAY allow continuation. | Both | EDP_07, RPRC_21 |
@@ -682,31 +674,31 @@ flowchart TD
 | AUTHZ-ISS-05 | The WI SHALL verify metadata signature and <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> certificate chain. | Issuance | ISSU_22a, ISSU_32a |
 | AUTHZ-ISS-06 | If metadata signature verification fails, produce NOT_AUTHORIZED (non-overridable). | Issuance | -- |
 | AUTHZ-ISS-07 | The WI SHALL extract authorization data from issuer_info per [ETSI TS 119 472-3] section 4.2.3. | Issuance | RPRC_22 |
-| AUTHZ-ISS-08 | Self-declared fallback from Credential Issuer Metadata SHALL be treated as advisory only. | Issuance | ISSU_24a note |
-| AUTHZ-ISS-09 | The WI SHALL NOT present self-declared entitlement information as verified. | Issuance | ISSU_24a note |
+| AUTHZ-ISS-08 | If <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> validation fails and no permitted <components:Register> check confirms the required authorization, the WI SHALL NOT use self-declared metadata as a fallback and SHALL block issuance. | Issuance | ISSU_24a note |
+| AUTHZ-ISS-09 | The WI SHALL NOT use self-declared metadata to authorize issuance or present it as verified registration information. | Issuance | ISSU_24a note |
 | AUTHZ-ISS-10 | On successful verification and User confirmation, proceed with issuance and store <artifacts:Embedded Disclosure Policy (EDP)\|EDP>. | Issuance | EDP_09 |
 | AUTHZ-PRES-01 | If User opted-in and registered scope available, the WI SHALL compare requested attributes against registered scope. | Presentation | RPRC_16, RPRC_21 |
 | AUTHZ-PRES-02 | If unregistered attributes detected, identify them and notify User. Override permitted. | Presentation | RPRC_21 |
 | AUTHZ-PRES-03 | Authorization logic SHALL be the same for remote and proximity flows. | Presentation | OIA_01 |
-| AUTHZ-PRES-04 | The WI SHALL offer a User setting for RP verification, enabled by default. | Presentation | RPRC_16 |
+| AUTHZ-PRES-04 | The WI SHALL offer a User setting for optional scope comparison, enabled by default. The setting SHALL NOT disable the mandatory <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> check. | Presentation | RPRC_16 |
 | AUTHZ-PRES-05 | The WI SHALL extract <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> per applicable flow (verifier_info or euWrprc). | Presentation | RPRC_19, RPRC_20 |
-| AUTHZ-PRES-06 | If authorization data cannot be obtained, notify User and proceed with advisory. | Presentation | RPRC_18 |
+| AUTHZ-PRES-06 | If authorization data cannot be obtained, the WI SHALL NOT use self-declared metadata as a fallback; it SHALL notify User and proceed only with an advisory and the applicable override rules. | Presentation | RPRC_18 |
 | AUTHZ-PRES-07 | The WI SHALL verify entitlements and binding after data extraction. | Presentation | RPRC_16 |
 | AUTHZ-PRES-08 | The WI SHALL verify Service_Provider entitlement. | Presentation | -- |
 | AUTHZ-PRES-09 | The WI SHALL inform User of scope comparison results. | Presentation | RPRC_21 |
-| AUTHZ-PRES-10 | Remote: RP Instance SHALL include RPRC_19a extension fields and <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> by value if available. | Presentation | RPRC_19, RPRC_19a |
+| AUTHZ-PRES-10 | Remote: RP Instance SHALL include RPRC_19a extension fields and the <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> by value. | Presentation | RPRC_19, RPRC_19a |
 | AUTHZ-PRES-11 | Proximity: <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> SHALL be CWT, attributes from device request <data-elements:Namespace\|namespaces>. | Presentation | RPRC_20, OIA_01 |
 | AUTHZ-INT-01 | Intermediary scenario detected when <artifacts:Wallet-Relying Party Access Certificate (WRPAC)\|WRPAC> subject identifier differs from RPRC_19a claimed RP identifier. Detection is performed before <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> examination. | Presentation | RPI_07 |
 | AUTHZ-INT-02 | In intermediary scenarios, authorization inputs SHALL apply to intermediated RP; WI SHALL verify intermediary association. | Presentation | RPI_01 - RPI_10 |
 | AUTHZ-INT-03 | If intermediary binding fails, produce NOT_AUTHORIZED (non-overridable). | Presentation | RPI_07a |
 | AUTHZ-INT-04 | Intermediary handling applies to both remote and proximity flows. | Presentation | RPI_01 - RPI_10 |
-| AUTHZ-INT-05 | For intermediated presentation, the WI SHALL process minimum fields about the final RP. | Presentation | RPRC_19a, RPI_07 |
+| AUTHZ-INT-05 | For intermediated presentation, the WI SHALL process and display the minimum required fields about the final RP; the intermediary identity SHALL NOT be displayed. | Presentation | RPRC_19a |
 | AUTHZ-INT-06 | Negative cases for intermediated presentation: missing final RP info, binding failure, missing authoritative data, negative <artifacts:Embedded Disclosure Policy (EDP)\|EDP>, negative scope. | Presentation | -- |
 | AUTHZ-INT-07 | Override permitted only for negative scope and negative <artifacts:Embedded Disclosure Policy (EDP)\|EDP> in intermediated presentation. | Presentation | EDP_07, RPRC_21 |
 | AUTHZ-REG-01 | The WI SHALL verify authenticity and integrity of <components:Register> response before relying on it. | Both | RPRC_18 |
 | AUTHZ-REG-02 | The WI SHALL verify <components:Register> response pertains to the relevant subject and intended use. | Both | -- |
 | AUTHZ-REG-03 | The WI SHALL normalize <components:Register>-derived data into the same model used for <artifacts:Wallet-Relying Party Registration Certificate (WRPRC)\|WRPRC> data. | Both | -- |
-| AUTHZ-REG-04 | If required authoritative information cannot be obtained from <components:Register>, for issuance apply fallback; for presentation notify User. | Both | RPRC_18 |
+| AUTHZ-REG-04 | If a permitted <components:Register> query is used and required authoritative information cannot be obtained, the WI SHALL NOT use self-declared metadata as a fallback; for both issuance and presentation it SHALL stop the interaction and SHALL notify User. | Both | RPRC_18 |
 | AUTHZ-<artifacts:Embedded Disclosure Policy (EDP)\|EDP>-01 | The WI SHALL support <artifacts:Embedded Disclosure Policy (EDP)\|EDP> for QEAAs, PuB-EAAs, non-qualified EAAs. SHALL NOT assume PIDs have <artifacts:Embedded Disclosure Policy (EDP)\|EDP>. | Presentation | EDP_01 |
 | AUTHZ-<artifacts:Embedded Disclosure Policy (EDP)\|EDP>-02 | During issuance, the WI SHALL store <artifacts:Embedded Disclosure Policy (EDP)\|EDP> locally if present. | Issuance | EDP_09, EDP_10 |
 | AUTHZ-<artifacts:Embedded Disclosure Policy (EDP)\|EDP>-03 | At presentation, the WI SHALL check locally stored <artifacts:Embedded Disclosure Policy (EDP)\|EDP> for each matching Attestation. | Presentation | EDP_06, EDP_10 |


### PR DESCRIPTION
Together with #115, this PR resolves #117 by making the usage of WRPRC mandatory in the Authorization process aligning with ARF 3.0.0 